### PR TITLE
add transceivers for audio and video

### DIFF
--- a/packages/realtime-core/src/RealtimeConnection/RealtimeConnectionMediaManager.ts
+++ b/packages/realtime-core/src/RealtimeConnection/RealtimeConnectionMediaManager.ts
@@ -110,13 +110,13 @@ export class RealtimeConnectionMediaManager {
       }
     }
 
-    // if (this._config.addTransceivers) {
-    //   setupMediaResponse = this.setupTransceiver(this._config.addTransceivers);
+    if (this._config.addTransceivers) {
+      setupMediaResponse = this.setupTransceiver(this._config.addTransceivers);
 
-    //   if (!setupMediaResponse.ok) {
-    //     this._logger?.warn(this._logLabel, "Unable to add transceiver.");
-    //   }
-    // }
+      if (!setupMediaResponse.ok) {
+        this._logger?.warn(this._logLabel, "Unable to add transceiver.");
+      }
+    }
 
     this._isSetupCompleted = true;
 
@@ -187,6 +187,11 @@ export class RealtimeConnectionMediaManager {
           this._peerConnection.addTransceiver(
             transceiver.kind,
             transceiver.options
+          );
+          this._logger?.info(
+            this._logLabel,
+            "Added transceiver for",
+            transceiver.kind
           );
         });
       }

--- a/packages/realtime-core/src/create-config.ts
+++ b/packages/realtime-core/src/create-config.ts
@@ -39,8 +39,6 @@ export type TCreateConfigInput = {
   rtcConfig?: RTCConfiguration;
   /** Optional logger for logging purposes. */
   logger?: TLogger;
-  /** Optional Transceivers to add */
-  // addTransceivers?: TTransceiver[];
 };
 
 /**
@@ -70,7 +68,6 @@ export function createConfig(input: TCreateConfigInput): TRealtimeConfig {
     logger,
     audioDeviceId,
     videoDeviceId,
-    // addTransceivers,
   } = input;
 
   // Ensure that either functionURL or offerURL is provided
@@ -80,6 +77,7 @@ export function createConfig(input: TCreateConfigInput): TRealtimeConfig {
 
   let audio: TAudioConfig = false;
   let video: TVideoConfig = false;
+  const addTransceivers: TTransceiver[] = [];
 
   // Combine audio constraints with the provided audio device ID
   if (audioConstraints || audioDeviceId) {
@@ -97,6 +95,36 @@ export function createConfig(input: TCreateConfigInput): TRealtimeConfig {
     };
   }
 
+  if (!audio) {
+    /**
+     * If local audio constraints is missing, meaning
+     * we don't want to stream local audio. In this case
+     * to receive any audio track from the backend we need
+     * to add a transceiver for audio.
+     */
+    addTransceivers.push({
+      kind: "audio",
+      options: {
+        direction: "recvonly",
+      },
+    });
+  }
+
+  if (!video) {
+    /**
+     * If local video constraints is missing, meaning
+     * we don't want to add stream local video. In this case
+     * to receive any video track from the backend we need
+     * to add a transceiver for video.
+     */
+    addTransceivers.push({
+      kind: "video",
+      options: {
+        direction: "recvonly",
+      },
+    });
+  }
+
   // Construct the real-time configuration object
   const config: TRealtimeConfig = {
     functionURL,
@@ -111,7 +139,7 @@ export function createConfig(input: TCreateConfigInput): TRealtimeConfig {
     video,
     screen: screenConstraints,
     logger,
-    // addTransceivers,
+    addTransceivers,
   };
 
   // Add codec configurations if provided

--- a/packages/realtime-core/src/shared/@types.ts
+++ b/packages/realtime-core/src/shared/@types.ts
@@ -142,7 +142,7 @@ export type TRealtimeConfig = {
    *  ]
    * }
    */
-  // addTransceivers?: TTransceiver[];
+  addTransceivers?: TTransceiver[];
 
   /**
    * Configuration for video transformations, such as filters or effects applied to the video stream.


### PR DESCRIPTION
# Summary

This PR implements logic to add a `recvonly` transceiver for `audio` when no local audio track is present, for `video` when no local video track is present, or for both when neither is present.

# Changes
1. In `RealtimeConnectionMediaManager`, the logic to set up transceivers has been uncommented, and logging has been added to indicate when a transceiver is added.
2. In `createConfig`, transceiver configuration has been added. If the local `audio` track is missing, an audio transceiver is added, and similarly, a video transceiver is added if the local `video` track is missing.

# Testing

None.

# Note

Before testing locally, ensure that `@adaptai/realtime-core` is built, or run `pnpm build` from the root directory.